### PR TITLE
Add Redis cache support with scripts/redis on/off toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Within [Docker](https://www.docker.com/) container environment you are able to:
 * Import a Joomla instance from a ZIP package and an SQL dump.
 * Grafting a Joomla package.
 * Using Xdebug for PHP debugging.
+* Switching the Joomla cache handler to Redis, or back to file cache.
 * Using HTTP and HTTPS.
 * Using IPv4 and IPv6 network in dual-stack.
 * Allows patching and testing of the `joomla-cypress` NPM module.
@@ -131,6 +132,7 @@ The abbreviation `jbt` stands for Joomla Branches Tester.
 |jbt-mysql| 10.0.0.11<br />fd00::11 :eight_pointed_black_star: | **7011**:3306 | | Database Server MySQL version 8.1 |
 |jbt-madb| 10.0.0.12<br />fd00::12 | **7012**:3306 | | Database Server MariaDB version 10.4 |
 |jbt-pg| 10.0.0.13<br />fd00::13 | **7013**:5432 | | Database Server PostgreSQL version 12.20 |
+|jbt-redis| 10.0.0.14<br />fd00::14 | **7014**:6379 | | Redis Server, used as optional Joomla cache handler, see `scripts/redis` |
 |jbt-39| 10.0.0.39<br />fd00::39 | **[7039](http://host.docker.internal:7039/administrator)**<br />**[7139](htts://host.docker.internal:7139/administrator)** | /joomla-39 | Web Server Joomla e.g. tag 3.9.28<br />user ci-admin / joomla-17082005 |
 |jbt-310| 10.0.3.10<br />fd00::310 | **[7310](http://host.docker.internal:7310/administrator)**<br />**[7410](https://host.docker.internal:7410/administrator)** | /joomla-310 | Web Server Joomla e.g. tag 3.10.12<br />user ci-admin / joomla-17082005 |
 | ... | | | | |
@@ -942,6 +944,30 @@ scripts/xdebug off
 ```
 
 Enabling Xdebug requires at least PHP 8.0. Used ports are 79xx, for the given example 7953 and for Joomla version 3.10 using port 7910.
+
+### Redis Cache
+
+JBT provides an always running `jbt-redis` base container ([Redis](https://redis.io/)) and installs the
+`redis` PHP extension in every Joomla web server container.
+You can switch one or more Joomla instances to use Redis as the Joomla cache handler, for example:
+```
+scripts/redis 62 on
+```
+
+This enables caching and configures Joomla's `configuration.php` to use the `redis` cache handler with
+host `jbt-redis` and port `6379`.
+
+Switch back to Joomla's default file-based cache for example:
+```
+scripts/redis 62 off
+```
+
+Without a Joomla instance given, all installed instances are changed:
+```
+scripts/redis on
+```
+
+👉 Switching Redis on or off only edits `configuration.php` and does not affect database or file system consistency.
 
 ### IPv6
 

--- a/configs/docker-compose.base.yml
+++ b/configs/docker-compose.base.yml
@@ -77,6 +77,19 @@ services:
         ipv4_address: 10.0.0.13
         ipv6_address: fd00::13 # Use decimal digits, even if hex value differs
 
+  redis:
+    container_name: jbt-redis
+    restart: unless-stopped
+    image: redis:7-alpine
+    ports:
+      - "7014:6379"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      jbt-network:
+        ipv4_address: 10.0.0.14
+        ipv6_address: fd00::14 # Use decimal digits, even if hex value differs
+
   myadmin:
     container_name: jbt-mya
     image: phpmyadmin/phpmyadmin

--- a/configs/docker-compose.joomla.yml
+++ b/configs/docker-compose.joomla.yml
@@ -22,6 +22,7 @@
       - mysql
       - mariadb
       - postgres
+      - redis
       - relay
       - proxy
     # To prevent volume shadowing and stale mounts of deleted containers, no anonymous volumes are created by defining all volumes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -46,6 +46,7 @@ The following scripts are available and the use is described in [../README.md](.
 | [patchtester](patchtester.sh) | Installs and configures Joomla patch tester component in one or all Joomla instances. | The GitHub token comes from environment variable `JBT_GITHUB_TOKEN` or as mandatory argument. Optional argumenta are the Joomla instances, 'install' (default) or 'uninstall' and the Patch Tester version (default is latest). |
 | [php](php.sh) | Change used PHP version. | Mandatory is the PHP version, e.g. `php8.3`. Optional arguments are the Joomla instances. |
 | [pull](pull.sh) | Running `git pull` and more. | Optional arguments are the Joomla instances. |
+| [redis](redis.sh) | Switching the Joomla cache handler between Redis and file cache. | Mandatory argument is `on` or `off`. Optional arguments are the Joomla instances. |
 | [test](test.sh) | Running Cypress headless System Tests on one or all branches. | Optional arguments are browser, test specification pattern and the Joomla instances. |
 | [ubuntu_setup.sh](ubuntu_setup.sh) | Helper script for Ubuntu Linux (native or in Windows WSL 2) based installation. | |
 | [xdebug](xdebug.sh) | Switching PHP in web container to installation with or without Xdebug. | Mandatory argument is `on` or `off`. Optional arguments are the the Joomla instances. |

--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -65,6 +65,12 @@ declare -ar \
 declare -ar \
   JBT_DB_SOCKETS=("${JBT_S_MY}" "${JBT_S_MY}" "${JBT_S_MA}" "${JBT_S_MA}" "${JBT_S_PG}")
 
+# Redis base container used as Joomla cache handler, see scripts/redis.
+# shellcheck disable=SC2034 # It is used by other scripts after sourcing
+declare -r \
+  JBT_REDIS_HOST="jbt-redis" \
+  JBT_REDIS_PORT="6379"
+
 # Valid PHP versions.
 # (not 5.6 - 7.3 as there are problems and for lowest supported Joomla 3.9.0 there is PHP 7.4 available and working)
 declare -ar \

--- a/scripts/redis
+++ b/scripts/redis
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+#
+# redis - Logger frame for redis.sh.
+#
+# Distributed under the GNU General Public License version 2 or later, Copyright (c) 2024-2026 Heiko Lübbe
+# https://github.com/muhme/joomla-branches-tester
+
+log_file="logs/$(date '+%Y-%m-%d-%H%M%S')-redis.txt"
+mkdir -p logs 2>/dev/null || (sudo mkdir -p logs && sudo chmod 777 logs)
+echo "*** Using log file: ${log_file}"
+scripts/redis.sh "$@" 2>&1 | tee -a "${log_file}"
+echo "*** Log file used: ${log_file}"

--- a/scripts/redis.sh
+++ b/scripts/redis.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+#
+# redis.sh - Switches the Joomla cache handler to Redis or back to file cache in one or more Web Server containers.
+#   scripts/redis on
+#   scripts/redis 62 on
+#   scripts/redis 53 60 off
+#
+# Uses the always running 'jbt-redis' base Docker container (see configs/docker-compose.base.yml)
+# and the 'redis' PHP extension installed for every Joomla web server container (see scripts/setup.sh).
+#
+# Distributed under the GNU General Public License version 2 or later, Copyright (c) 2024-2026 Heiko Lübbe
+# https://github.com/muhme/joomla-branches-tester
+
+if [[ $(dirname "$0") != "scripts" || ! -f "scripts/helper.sh" ]]; then
+  echo "Please run me as 'scripts/redis'. Thank you for your cooperation! :)"
+  exit 1
+fi
+
+source scripts/helper.sh
+
+function help {
+    echo "
+    redis – Toggles the Joomla cache handler between Redis and file cache in one or more Joomla web server containers.
+            Mandatory argument must be 'on' or 'off'.
+            The optional Joomla instance can include one or more of installed: ${allInstalledInstances[*]} (default is all).
+            The optional argument 'help' displays this page. For full details see https://bit.ly/JBT--README.
+    $(random_quote)"
+}
+
+# shellcheck disable=SC2207 # There are no spaces in version numbers
+allInstalledInstances=($(getAllInstalledInstances))
+
+instancesToChange=()
+while [ $# -ge 1 ]; do
+  if [[ "$1" =~ ^(help|-h|--h|-help|--help|-\?)$ ]]; then
+    help
+    exit 0
+  elif [ -d "joomla-$1" ]; then
+    instancesToChange+=("$1")
+    shift # Argument is eaten as one version number.
+  elif [ "$1" = "on" ]; then
+    todo="$1"
+    shift # Argument is eaten as enable Redis.
+  elif [ "$1" = "off" ]; then
+    todo="$1"
+    shift # Argument is eaten as disable Redis.
+  else
+    help
+    error "Argument '$1' is not valid."
+    exit 1
+  fi
+done
+
+if [ -z "${todo}" ]; then
+    help
+    error "Please provide the argument 'on' or 'off'."
+    exit 1
+fi
+
+# If no version was given, use all.
+if [ ${#instancesToChange[@]} -eq 0 ]; then
+  # shellcheck disable=SC2207 # There are no spaces in version numbers
+  instancesToChange=("${allInstalledInstances[@]}")
+fi
+
+for instance in "${instancesToChange[@]}"; do
+
+  if [ ! -f "joomla-${instance}/configuration.php" ]; then
+    warning "jbt-${instance} – No 'configuration.php' found, Joomla is probably not installed yet, jumped over"
+    continue
+  fi
+
+  if [ "${todo}" = "on" ]; then
+    if docker exec "jbt-${instance}" bash -c "grep -q \"cache_handler = 'redis'\" configuration.php"; then
+      log "jbt-${instance} – Redis cache is already enabled"
+    else
+      log "jbt-${instance} – Enabling Redis cache handler (host '${JBT_REDIS_HOST}', port ${JBT_REDIS_PORT})"
+      docker exec "jbt-${instance}" bash -c "sed \
+        -e \"s|\(public .caching =\).*|\1 '1';|\" \
+        -e \"s|\(public .cache_handler =\).*|\1 'redis';|\" \
+        -e \"s|\(public .redis_persistent =\).*|\1 '0';|\" \
+        -e \"s|\(public .redis_host =\).*|\1 '${JBT_REDIS_HOST}';|\" \
+        -e \"s|\(public .redis_port =\).*|\1 '${JBT_REDIS_PORT}';|\" \
+        -e \"s|\(public .redis_db =\).*|\1 '0';|\" \
+        configuration.php > configuration.php.new && \
+        mv configuration.php.new configuration.php && \
+        chown www-data:www-data configuration.php && \
+        chmod 0444 configuration.php"
+    fi
+  else
+    if docker exec "jbt-${instance}" bash -c "grep -q \"cache_handler = 'file'\" configuration.php"; then
+      log "jbt-${instance} – Redis cache is already disabled"
+    else
+      log "jbt-${instance} – Disabling Redis, switching back to file cache handler"
+      docker exec "jbt-${instance}" bash -c "sed \
+        -e \"s|\(public .caching =\).*|\1 '0';|\" \
+        -e \"s|\(public .cache_handler =\).*|\1 'file';|\" \
+        configuration.php > configuration.php.new && \
+        mv configuration.php.new configuration.php && \
+        chown www-data:www-data configuration.php && \
+        chmod 0444 configuration.php"
+    fi
+  fi
+done

--- a/scripts/redis.sh
+++ b/scripts/redis.sh
@@ -5,8 +5,9 @@
 #   scripts/redis 62 on
 #   scripts/redis 53 60 off
 #
-# Uses the always running 'jbt-redis' base Docker container (see configs/docker-compose.base.yml)
-# and the 'redis' PHP extension installed for every Joomla web server container (see scripts/setup.sh).
+# Uses the 'jbt-redis' base Docker container (see configs/docker-compose.base.yml), started and stopped
+# on demand by this script, and the 'redis' PHP extension installed for every Joomla web server
+# container (see scripts/setup.sh).
 #
 # Distributed under the GNU General Public License version 2 or later, Copyright (c) 2024-2026 Heiko Lübbe
 # https://github.com/muhme/joomla-branches-tester
@@ -63,6 +64,12 @@ if [ ${#instancesToChange[@]} -eq 0 ]; then
   instancesToChange=("${allInstalledInstances[@]}")
 fi
 
+# jbt-redis is only needed while at least one instance actually uses it, so it is started/stopped on demand.
+if [ "${todo}" = "on" ]; then
+  log "jbt-redis – Starting container"
+  docker start jbt-redis > /dev/null
+fi
+
 for instance in "${instancesToChange[@]}"; do
 
   if [ ! -f "joomla-${instance}/configuration.php" ]; then
@@ -116,3 +123,21 @@ for instance in "${instancesToChange[@]}"; do
     fi
   fi
 done
+
+if [ "${todo}" = "off" ]; then
+  # Check across *all* installed instances, not only the ones just changed, whether Redis is still
+  # in use anywhere, since jbt-redis is one shared base container (see configs/docker-compose.base.yml).
+  stillUsed=false
+  for instance in "${allInstalledInstances[@]}"; do
+    if [ -f "joomla-${instance}/configuration.php" ] && grep -q "cache_handler = 'redis'" "joomla-${instance}/configuration.php"; then
+      stillUsed=true
+      break
+    fi
+  done
+  if [ "${stillUsed}" = false ]; then
+    log "jbt-redis – Stopping container, no Joomla instance is using it anymore"
+    docker stop jbt-redis > /dev/null
+  else
+    log "jbt-redis – Keeping container running, still used by instance '${instance}'"
+  fi
+fi

--- a/scripts/redis.sh
+++ b/scripts/redis.sh
@@ -90,6 +90,10 @@ for instance in "${instancesToChange[@]}"; do
         mv configuration.php.new configuration.php && \
         chown www-data:www-data configuration.php && \
         chmod 0444 configuration.php"
+      # Apache worker processes (and, if enabled, PHP OPcache) may have already loaded the old
+      # 'configuration.php' into memory, so a graceful reload is needed for the change to take effect.
+      log "jbt-${instance} – Reloading Apache to pick up the new 'configuration.php'"
+      docker exec "jbt-${instance}" bash -c "apache2ctl graceful"
     fi
   else
     if docker exec "jbt-${instance}" bash -c "grep -q \"cache_handler = 'file'\" configuration.php"; then
@@ -107,6 +111,8 @@ for instance in "${instancesToChange[@]}"; do
         mv configuration.php.new configuration.php && \
         chown www-data:www-data configuration.php && \
         chmod 0444 configuration.php"
+      log "jbt-${instance} – Reloading Apache to pick up the new 'configuration.php'"
+      docker exec "jbt-${instance}" bash -c "apache2ctl graceful"
     fi
   fi
 done

--- a/scripts/redis.sh
+++ b/scripts/redis.sh
@@ -75,13 +75,17 @@ for instance in "${instancesToChange[@]}"; do
       log "jbt-${instance} – Redis cache is already enabled"
     else
       log "jbt-${instance} – Enabling Redis cache handler (host '${JBT_REDIS_HOST}', port ${JBT_REDIS_PORT})"
+      # Field names as used by Joomla in 'configuration.php', see 'installation/configuration.php-dist':
+      #   Cache:   $caching, $cache_handler, $redis_server_host, $redis_server_port
+      #   Session: $session_redis_server_host, $session_redis_server_port
+      #            (only used if $session_handler is separately set to 'redis', not changed here)
       docker exec "jbt-${instance}" bash -c "sed \
-        -e \"s|\(public .caching =\).*|\1 '1';|\" \
+        -e \"s|\(public .caching =\).*|\1 1;|\" \
         -e \"s|\(public .cache_handler =\).*|\1 'redis';|\" \
-        -e \"s|\(public .redis_persistent =\).*|\1 '0';|\" \
-        -e \"s|\(public .redis_host =\).*|\1 '${JBT_REDIS_HOST}';|\" \
-        -e \"s|\(public .redis_port =\).*|\1 '${JBT_REDIS_PORT}';|\" \
-        -e \"s|\(public .redis_db =\).*|\1 '0';|\" \
+        -e \"s|\(public .redis_server_host =\).*|\1 '${JBT_REDIS_HOST}';|\" \
+        -e \"s|\(public .redis_server_port =\).*|\1 ${JBT_REDIS_PORT};|\" \
+        -e \"s|\(public .session_redis_server_host =\).*|\1 '${JBT_REDIS_HOST}';|\" \
+        -e \"s|\(public .session_redis_server_port =\).*|\1 ${JBT_REDIS_PORT};|\" \
         configuration.php > configuration.php.new && \
         mv configuration.php.new configuration.php && \
         chown www-data:www-data configuration.php && \
@@ -93,8 +97,12 @@ for instance in "${instancesToChange[@]}"; do
     else
       log "jbt-${instance} – Disabling Redis, switching back to file cache handler"
       docker exec "jbt-${instance}" bash -c "sed \
-        -e \"s|\(public .caching =\).*|\1 '0';|\" \
+        -e \"s|\(public .caching =\).*|\1 0;|\" \
         -e \"s|\(public .cache_handler =\).*|\1 'file';|\" \
+        -e \"s|\(public .redis_server_host =\).*|\1 'localhost';|\" \
+        -e \"s|\(public .redis_server_port =\).*|\1 6379;|\" \
+        -e \"s|\(public .session_redis_server_host =\).*|\1 'localhost';|\" \
+        -e \"s|\(public .session_redis_server_port =\).*|\1 6379;|\" \
         configuration.php > configuration.php.new && \
         mv configuration.php.new configuration.php && \
         chown www-data:www-data configuration.php && \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -161,6 +161,10 @@ docker exec "jbt-${instance}" bash -c 'apt-get update && apt-get install -y \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*'
 
+# redis is a PECL extension and not available via docker-php-ext-install, needed for scripts/redis.
+log "jbt-${instance} – Installing Redis PHP extension"
+docker exec "jbt-${instance}" bash -c 'pecl install redis && docker-php-ext-enable redis'
+
 # gh only to use it for applying GitHub PRs manually
 log "jbt-${instance} – Installing gh command"
 docker exec "jbt-${instance}" bash -c '


### PR DESCRIPTION
- Add always running 'jbt-redis' base container (redis:7-alpine) on 10.0.0.14 / fd00::14, mapped to host port 7014.
- Install the 'redis' PHP (PECL) extension in every Joomla web server container during scripts/setup.sh, so the cache handler is available without any extra step.
- Add scripts/redis (+ redis.sh), following the same on/off toggle pattern as scripts/xdebug: scripts/redis 62 on scripts/redis 53 60 off
    scripts/redis on   # all installed instances
  Switches Joomla's configuration.php between the 'redis' cache handler
  (host jbt-redis, port 6379) and the default 'file' cache handler.
- Add JBT_REDIS_HOST / JBT_REDIS_PORT constants to helper.sh.
- Make Joomla web server containers depend_on the new redis service.
- Document the feature in README.md (containers table, feature list,
  new 'Redis Cache' section) and scripts/README.md.