### PR TITLE
Add memcached.sh for managing Joomla cache handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The abbreviation `jbt` stands for Joomla Branches Tester.
 |jbt-madb| 10.0.0.12<br />fd00::12 | **7012**:3306 | | Database Server MariaDB version 10.4 |
 |jbt-pg| 10.0.0.13<br />fd00::13 | **7013**:5432 | | Database Server PostgreSQL version 12.20 |
 |jbt-redis| 10.0.0.14<br />fd00::14 | **7014**:6379 | | Redis Server, used as optional Joomla in-memory cache |
+|jbt-memcached| 10.0.0.15<br />fd00::15 | **7015**:11211 | | Memcached Server, used as optional Joomla cache handler, see `scripts/memcached` |
 |jbt-39| 10.0.0.39<br />fd00::39 | **[7039](http://host.docker.internal:7039/administrator)**<br />**[7139](htts://host.docker.internal:7139/administrator)** | /joomla-39 | Web Server Joomla e.g. tag 3.9.28<br />user ci-admin / joomla-17082005 |
 |jbt-310| 10.0.3.10<br />fd00::310 | **[7310](http://host.docker.internal:7310/administrator)**<br />**[7410](https://host.docker.internal:7410/administrator)** | /joomla-310 | Web Server Joomla e.g. tag 3.10.12<br />user ci-admin / joomla-17082005 |
 | ... | | | | |

--- a/configs/docker-compose.base.yml
+++ b/configs/docker-compose.base.yml
@@ -91,6 +91,20 @@ services:
         ipv4_address: 10.0.0.14
         ipv6_address: fd00::14 # Use decimal digits, even if hex value differs
 
+  memcached:
+    container_name: jbt-memcached
+    restart: unless-stopped
+    image: memcached:1.6-alpine
+    ports:
+      - "7015:11211"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      jbt-network:
+        ipv4_address: 10.0.0.15
+        ipv6_address: fd00::15 # Use decimal digits, even if hex value differs
+
+
   myadmin:
     container_name: jbt-mya
     image: phpmyadmin/phpmyadmin

--- a/configs/docker-compose.joomla.yml
+++ b/configs/docker-compose.joomla.yml
@@ -24,6 +24,7 @@
       - mariadb
       - postgres
       - redis
+      - memcached
       - relay
       - proxy
     # To prevent volume shadowing and stale mounts of deleted containers, no anonymous volumes are created by defining all volumes.

--- a/scripts/helper.sh
+++ b/scripts/helper.sh
@@ -71,6 +71,12 @@ declare -ar \
 declare -r \
   JBT_REDIS_HOST="jbt-redis" \
   JBT_REDIS_PORT="6379"
+  
+# Memcached base container used as Joomla cache handler, see scripts/memcached.
+# shellcheck disable=SC2034 # It is used by other scripts after sourcing
+declare -r \
+  JBT_REDIS_HOST="jbt-memcached" \
+  JBT_REDIS_PORT="11211"
 
 # Valid PHP versions.
 # (not 5.6 - 7.3 as there are problems and for lowest supported Joomla 3.9.0 there is PHP 7.4 available and working)

--- a/scripts/memcached.sh
+++ b/scripts/memcached.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+#
+# memcached.sh - Switches the Joomla cache handler to Memcached or back to file cache in one or more Web Server containers.
+#   scripts/memcached on
+#   scripts/memcached 62 on
+#   scripts/memcached 53 60 off
+#
+# Uses the 'jbt-memcached' base Docker container (see configs/docker-compose.base.yml), started and stopped
+# on demand by this script, and the 'memcached' PHP extension installed for every Joomla web server
+# container (see scripts/setup.sh).
+#
+# Distributed under the GNU General Public License version 2 or later
+
+if [[ $(dirname "$0") != "scripts" || ! -f "scripts/helper.sh" ]]; then
+  echo "Please run me as 'scripts/memcached'. Thank you for your cooperation! :)"
+  exit 1
+fi
+
+source scripts/helper.sh
+
+function help {
+    echo "
+    memcached – Toggles the Joomla cache handler between Memcached and file cache in one or more Joomla web server containers.
+            Mandatory argument must be 'on' or 'off'.
+            The optional Joomla instance can include one or more of installed: ${allInstalledInstances[*]} (default is all).
+            The optional argument 'help' displays this page.
+    $(random_quote)"
+}
+
+# shellcheck disable=SC2207
+allInstalledInstances=($(getAllInstalledInstances))
+
+instancesToChange=()
+while [ $# -ge 1 ]; do
+  if [[ "$1" =~ ^(help|-h|--h|-help|--help|-\?)$ ]]; then
+    help
+    exit 0
+  elif [ -d "joomla-$1" ]; then
+    instancesToChange+=("$1")
+    shift
+  elif [ "$1" = "on" ]; then
+    todo="$1"
+    shift
+  elif [ "$1" = "off" ]; then
+    todo="$1"
+    shift
+  else
+    help
+    error "Argument '$1' is not valid."
+    exit 1
+  fi
+done
+
+if [ -z "${todo}" ]; then
+    help
+    error "Please provide the argument 'on' or 'off'."
+    exit 1
+fi
+
+if [ ${#instancesToChange[@]} -eq 0 ]; then
+  # shellcheck disable=SC2207
+  instancesToChange=("${allInstalledInstances[@]}")
+fi
+
+# jbt-memcached is started/stopped on demand
+if [ "${todo}" = "on" ]; then
+  log "jbt-memcached – Starting container"
+  docker start jbt-memcached > /dev/null
+fi
+
+for instance in "${instancesToChange[@]}"; do
+
+  if [ ! -f "joomla-${instance}/configuration.php" ]; then
+    warning "jbt-${instance} – No 'configuration.php' found, jumped over"
+    continue
+  fi
+
+  if [ "${todo}" = "on" ]; then
+    if docker exec "jbt-${instance}" bash -c "grep -q \"cache_handler = 'memcached'\" configuration.php"; then
+      log "jbt-${instance} – Memcached cache is already enabled"
+    else
+      log "jbt-${instance} – Enabling Memcached cache handler (host '${JBT_MEMCACHED_HOST:-10.0.0.15}', port ${JBT_MEMCACHED_PORT:-11211})"
+      
+      docker exec "jbt-${instance}" bash -c "sed \
+        -e \"s|\(public .caching =\).*|\1 1;|\" \
+        -e \"s|\(public .cache_handler =\).*|\1 'memcached';|\" \
+        -e \"s|\(public .memcached_server_host =\).*|\1 '${JBT_MEMCACHED_HOST:-10.0.0.15}';|\" \
+        -e \"s|\(public .memcached_server_port =\).*|\1 ${JBT_MEMCACHED_PORT:-11211};|\" \
+        -e \"s|\(public .session_memcached_server_host =\).*|\1 '${JBT_MEMCACHED_HOST:-10.0.0.15}';|\" \
+        -e \"s|\(public .session_memcached_server_port =\).*|\1 ${JBT_MEMCACHED_PORT:-11211};|\" \
+        configuration.php > configuration.php.new && \
+        mv configuration.php.new configuration.php && \
+        chown www-data:www-data configuration.php && \
+        chmod 0444 configuration.php"
+
+      log "jbt-${instance} – Reloading Apache to pick up the new 'configuration.php'"
+      docker exec "jbt-${instance}" bash -c "apache2ctl graceful"
+    fi
+  else
+    if docker exec "jbt-${instance}" bash -c "grep -q \"cache_handler = 'file'\" configuration.php"; then
+      log "jbt-${instance} – Memcached cache is already disabled"
+    else
+      log "jbt-${instance} – Disabling Memcached, switching back to file cache handler"
+      docker exec "jbt-${instance}" bash -c "sed \
+        -e \"s|\(public .caching =\).*|\1 0;|\" \
+        -e \"s|\(public .cache_handler =\).*|\1 'file';|\" \
+        -e \"s|\(public .memcached_server_host =\).*|\1 'localhost';|\" \
+        -e \"s|\(public .memcached_server_port =\).*|\1 11211;|\" \
+        -e \"s|\(public .session_memcached_server_host =\).*|\1 'localhost';|\" \
+        -e \"s|\(public .session_memcached_server_port =\).*|\1 11211;|\" \
+        configuration.php > configuration.php.new && \
+        mv configuration.php.new configuration.php && \
+        chown www-data:www-data configuration.php && \
+        chmod 0444 configuration.php"
+        
+      log "jbt-${instance} – Reloading Apache to pick up the new 'configuration.php'"
+      docker exec "jbt-${instance}" bash -c "apache2ctl graceful"
+    fi
+  fi
+done
+
+if [ "${todo}" = "off" ]; then
+  stillUsed=false
+  for instance in "${allInstalledInstances[@]}"; do
+    if [ -f "joomla-${instance}/configuration.php" ] && grep -q "cache_handler = 'memcached'" "joomla-${instance}/configuration.php"; then
+      stillUsed=true
+      break
+    fi
+  done
+  if [ "${stillUsed}" = false ]; then
+    log "jbt-memcached – Stopping container, no Joomla instance is using it anymore"
+    docker stop jbt-memcached > /dev/null
+  else
+    log "jbt-memcached – Keeping container running, still used by instance '${instance}'"
+  fi
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -146,6 +146,7 @@ docker exec "jbt-${instance}" bash -c 'apt-get update && apt-get install -y \
   zstd \
   msmtp \
   msmtp-mta \
+  libmemcached-dev \
   && docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
   && docker-php-ext-install -j$(nproc) \
       gd \


### PR DESCRIPTION
This script manages the Joomla cache handler, allowing toggling between Memcached and file cache for multiple web server containers. It includes error handling and logging for operations.